### PR TITLE
add building docs to publish github workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -160,3 +160,10 @@ jobs:
 
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Build docs website
+        shell: bash -l {0}
+        run: |
+          git config user.name ci-bot
+          git config user.email ci-bot@ci.com
+          mike deploy --push --rebase --update-aliases ${RELEASE_TAG_VERSION} latest


### PR DESCRIPTION
Even though the code-base is still small now, it would be nice to have docs :)

(This does not add missing docstrings into the code itself)
